### PR TITLE
Add basic diary and habits tabs with date selector

### DIFF
--- a/HabitJourney/ContentView.swift
+++ b/HabitJourney/ContentView.swift
@@ -1,21 +1,19 @@
-//
-//  ContentView.swift
-//  HabitJourney
-//
-//  Created by Luca Barone on 20/6/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var dateManager = DateManager()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            DiaryView(manager: dateManager)
+                .tabItem {
+                    Label("Diary", systemImage: "book")
+                }
+            HabitsView(manager: dateManager)
+                .tabItem {
+                    Label("Habits", systemImage: "checkmark.circle")
+                }
         }
-        .padding()
     }
 }
 

--- a/HabitJourney/DateHeader.swift
+++ b/HabitJourney/DateHeader.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct DateHeader: View {
+    @ObservedObject var manager: DateManager
+    @State private var showPicker = false
+
+    var body: some View {
+        HStack {
+            Button(action: {
+                manager.selectedDate = Calendar.current.date(byAdding: .day, value: -1, to: manager.selectedDate) ?? manager.selectedDate
+            }) {
+                Image(systemName: "chevron.left")
+            }
+
+            Spacer()
+
+            Button(action: { showPicker.toggle() }) {
+                Text(dateString(manager.selectedDate))
+                    .font(.headline)
+            }
+            .sheet(isPresented: $showPicker) {
+                VStack {
+                    DatePicker("Select Date", selection: $manager.selectedDate, displayedComponents: .date)
+                        .datePickerStyle(GraphicalDatePickerStyle())
+                        .padding()
+                    Button("Done") { showPicker = false }
+                        .padding()
+                }
+                .presentationDetents([.medium])
+            }
+
+            Spacer()
+
+            Button(action: {
+                manager.selectedDate = Calendar.current.date(byAdding: .day, value: 1, to: manager.selectedDate) ?? manager.selectedDate
+            }) {
+                Image(systemName: "chevron.right")
+            }
+        }
+        .padding()
+    }
+
+    private func dateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+#Preview {
+    DateHeader(manager: DateManager())
+}

--- a/HabitJourney/DateManager.swift
+++ b/HabitJourney/DateManager.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+class DateManager: ObservableObject {
+    @Published var selectedDate: Date = Date()
+}

--- a/HabitJourney/DiaryView.swift
+++ b/HabitJourney/DiaryView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct DiaryView: View {
+    @ObservedObject var manager: DateManager
+
+    var body: some View {
+        VStack {
+            DateHeader(manager: manager)
+            Spacer()
+            Text("Diary for \(formattedDate)")
+            Spacer()
+        }
+    }
+
+    private var formattedDate: String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f.string(from: manager.selectedDate)
+    }
+}
+
+#Preview {
+    DiaryView(manager: DateManager())
+}

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct HabitsView: View {
+    @ObservedObject var manager: DateManager
+
+    var body: some View {
+        VStack {
+            DateHeader(manager: manager)
+            Spacer()
+            Text("Habits for \(formattedDate)")
+            Spacer()
+        }
+    }
+
+    private var formattedDate: String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f.string(from: manager.selectedDate)
+    }
+}
+
+#Preview {
+    HabitsView(manager: DateManager())
+}


### PR DESCRIPTION
## Summary
- implement `DateManager` observable object
- show a `DateHeader` with arrows and a date picker
- add `DiaryView` and `HabitsView` displaying the current date
- update `ContentView` to host a tabbed interface

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6855695966f0832fb4ef96c1b331dfdd