### PR TITLE
Add weekly habit tracking

### DIFF
--- a/HabitJourney/ContentView.swift
+++ b/HabitJourney/ContentView.swift
@@ -1,21 +1,21 @@
-//
-//  ContentView.swift
-//  HabitJourney
-//
-//  Created by Luca Barone on 20/6/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var dateManager = DateManager()
+    @StateObject private var diaryStore = DiaryStore()
+    @StateObject private var habitStore = HabitStore()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            DiaryView(manager: dateManager, store: diaryStore)
+                .tabItem {
+                    Label("Diary", systemImage: "book")
+                }
+            HabitsView(manager: dateManager, store: habitStore)
+                .tabItem {
+                    Label("Habits", systemImage: "checkmark.circle")
+                }
         }
-        .padding()
     }
 }
 

--- a/HabitJourney/DateHeader.swift
+++ b/HabitJourney/DateHeader.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct DateHeader: View {
+    @ObservedObject var manager: DateManager
+    @State private var showPicker = false
+
+    var body: some View {
+        HStack {
+            Button(action: {
+                manager.selectedDate = Calendar.current.date(byAdding: .day, value: -1, to: manager.selectedDate) ?? manager.selectedDate
+            }) {
+                Image(systemName: "chevron.left")
+            }
+
+            Spacer()
+
+            Button(action: { showPicker.toggle() }) {
+                Text(dateString(manager.selectedDate))
+                    .font(.headline)
+            }
+            .sheet(isPresented: $showPicker) {
+                VStack {
+                    DatePicker("Select Date", selection: $manager.selectedDate, displayedComponents: .date)
+                        .datePickerStyle(GraphicalDatePickerStyle())
+                        .padding()
+                    Button("Done") { showPicker = false }
+                        .padding()
+                }
+                .presentationDetents([.medium])
+            }
+
+            Spacer()
+
+            Button(action: {
+                manager.selectedDate = Calendar.current.date(byAdding: .day, value: 1, to: manager.selectedDate) ?? manager.selectedDate
+            }) {
+                Image(systemName: "chevron.right")
+            }
+        }
+        .padding()
+    }
+
+    private func dateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+#Preview {
+    DateHeader(manager: DateManager())
+}

--- a/HabitJourney/DateManager.swift
+++ b/HabitJourney/DateManager.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+class DateManager: ObservableObject {
+    @Published var selectedDate: Date = Date()
+}

--- a/HabitJourney/DiaryEntry.swift
+++ b/HabitJourney/DiaryEntry.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct DiaryEntry: Identifiable, Codable {
+    let id: UUID
+    var thoughts: String
+    var emotions: String
+    
+    init(id: UUID = UUID(), thoughts: String = "", emotions: String = "") {
+        self.id = id
+        self.thoughts = thoughts
+        self.emotions = emotions
+    }
+}

--- a/HabitJourney/DiaryStore.swift
+++ b/HabitJourney/DiaryStore.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftUI
+
+class DiaryStore: ObservableObject {
+    @Published private(set) var entries: [Date: DiaryEntry] = [:]
+    
+    func entry(for date: Date) -> DiaryEntry? {
+        let day = Calendar.current.startOfDay(for: date)
+        return entries[day]
+    }
+    
+    func updateEntry(for date: Date, thoughts: String, emotions: String) {
+        let day = Calendar.current.startOfDay(for: date)
+        let entry = DiaryEntry(thoughts: thoughts, emotions: emotions)
+        entries[day] = entry
+    }
+}

--- a/HabitJourney/DiaryView.swift
+++ b/HabitJourney/DiaryView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct DiaryView: View {
+    @ObservedObject var manager: DateManager
+    @ObservedObject var store: DiaryStore
+    @State private var showEditor = false
+    @State private var draftThoughts = ""
+    @State private var draftEmotions = ""
+
+    var body: some View {
+        VStack {
+            DateHeader(manager: manager)
+
+            if let entry = store.entry(for: manager.selectedDate) {
+                VStack(alignment: .leading) {
+                    Text("Thoughts").font(.headline)
+                    Text(entry.thoughts).padding(.bottom)
+                    Text("Emotions").font(.headline)
+                    Text(entry.emotions)
+                }
+                .padding()
+            } else {
+                Text("No entry for \(formattedDate)")
+                    .foregroundColor(.secondary)
+                    .padding()
+            }
+
+            Spacer()
+
+            Button(store.entry(for: manager.selectedDate) == nil ? "Add Entry" : "Edit Entry") {
+                let existing = store.entry(for: manager.selectedDate)
+                draftThoughts = existing?.thoughts ?? ""
+                draftEmotions = existing?.emotions ?? ""
+                showEditor = true
+            }
+            .padding()
+        }
+        .sheet(isPresented: $showEditor) {
+            NavigationView {
+                Form {
+                    Section(header: Text("Thoughts")) {
+                        TextEditor(text: $draftThoughts).frame(minHeight: 100)
+                    }
+                    Section(header: Text("Emotions")) {
+                        TextEditor(text: $draftEmotions).frame(minHeight: 100)
+                    }
+                }
+                .navigationTitle("Diary Entry")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            store.updateEntry(for: manager.selectedDate, thoughts: draftThoughts, emotions: draftEmotions)
+                            showEditor = false
+                        }
+                    }
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { showEditor = false }
+                    }
+                }
+            }
+        }
+    }
+
+    private var formattedDate: String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f.string(from: manager.selectedDate)
+    }
+}
+
+#Preview {
+    DiaryView(manager: DateManager(), store: DiaryStore())
+}

--- a/HabitJourney/HabitEntry.swift
+++ b/HabitJourney/HabitEntry.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Categories a main habit can belong to.
+enum HabitCategory: String, CaseIterable, Codable, Identifiable {
+    case learning = "Learning"
+    case body = "Body/Sport"
+    case other = "Other"
+
+    var id: String { rawValue }
+}
+
+/// A single sub-habit that contributes to the completion of a main habit.
+struct SubHabit: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var target: Int
+
+    init(id: UUID = UUID(), title: String = "", target: Int = 1) {
+        self.id = id
+        self.title = title
+        self.target = target
+    }
+}
+
+/// Main habit containing a set of sub-habits. The habit is completed once all
+/// sub-habits are completed for the day.
+struct Habit: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var category: HabitCategory
+    var subHabits: [SubHabit]
+
+    init(id: UUID = UUID(),
+         title: String = "",
+         category: HabitCategory = .other,
+         subHabits: [SubHabit] = []) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.subHabits = subHabits
+    }
+}

--- a/HabitJourney/HabitStore.swift
+++ b/HabitJourney/HabitStore.swift
@@ -1,0 +1,111 @@
+import Foundation
+import SwiftUI
+
+/// Stores the weekly habits and tracks daily progress for each of them.
+class HabitStore: ObservableObject {
+    /// Habits are organized by week. Each week can have at most three habits.
+    @Published private var weeklyHabits: [Date: [Habit]] = [:]
+    /// Mapping from day -> sub-habit id -> progress count.
+    @Published private var progress: [Date: [UUID: Int]] = [:]
+
+    // MARK: Habit management
+
+    /// Returns the habits for the week that contains the given date.
+    func habits(for date: Date) -> [Habit] {
+        let week = startOfWeek(for: date)
+        return weeklyHabits[week] ?? []
+    }
+
+    /// Adds a new habit for the week of the supplied date if the limit of
+    /// three has not been reached. A new habit always starts with one
+    /// sub-habit.
+    func addHabit(title: String,
+                  category: HabitCategory,
+                  subHabitTitle: String,
+                  target: Int,
+                  for date: Date) {
+        let week = startOfWeek(for: date)
+        guard weeklyHabits[week, default: []].count < 3 else { return }
+        let sub = SubHabit(title: subHabitTitle, target: target)
+        let habit = Habit(title: title, category: category, subHabits: [sub])
+        weeklyHabits[week, default: []].append(habit)
+    }
+
+    /// Rename an existing habit in a given week.
+    func renameHabit(_ habit: Habit, to newTitle: String, for date: Date) {
+        updateHabit(habit, for: date) { $0.title = newTitle }
+    }
+
+    /// Add a new sub-habit to an existing habit in the given week.
+    func addSubHabit(to habit: Habit, title: String, target: Int, for date: Date) {
+        updateHabit(habit, for: date) { $0.subHabits.append(SubHabit(title: title, target: target)) }
+    }
+
+    /// Helper used to modify a habit inside the storage.
+    private func updateHabit(_ habit: Habit, for date: Date, mutate: (inout Habit) -> Void) {
+        let week = startOfWeek(for: date)
+        guard var habits = weeklyHabits[week],
+              let index = habits.firstIndex(where: { $0.id == habit.id }) else { return }
+        var copy = habits[index]
+        mutate(&copy)
+        habits[index] = copy
+        weeklyHabits[week] = habits
+    }
+
+    // MARK: Progress helpers
+
+    /// Returns the progress for the given sub-habit on a specific day.
+    func progress(for subHabit: SubHabit, on date: Date) -> Int {
+        let day = Calendar.current.startOfDay(for: date)
+        return progress[day]?[subHabit.id] ?? 0
+    }
+
+    /// Sets the progress for a sub-habit on the provided date.
+    func setProgress(_ value: Int, for subHabit: SubHabit, on date: Date) {
+        let day = Calendar.current.startOfDay(for: date)
+        progress[day, default: [:]][subHabit.id] = value
+    }
+
+    /// Convenience method to increase progress by one.
+    func increment(_ subHabit: SubHabit, on date: Date) {
+        let current = progress(for: subHabit, on: date)
+        setProgress(current + 1, for: subHabit, on: date)
+    }
+
+    /// Status describing completion for a given day.
+    enum Status {
+        case completed, inProgress, missed
+    }
+
+    /// Returns the completion status for a sub-habit on a date based on progress.
+    func status(for subHabit: SubHabit, on date: Date) -> Status {
+        let count = progress(for: subHabit, on: date)
+        if count >= subHabit.target { return .completed }
+
+        let today = Calendar.current.startOfDay(for: Date())
+        let day = Calendar.current.startOfDay(for: date)
+        if day < today { return .missed }
+        return .inProgress
+    }
+
+    /// Returns the completion status for a main habit. A habit is complete
+    /// when all of its sub-habits are completed for the specified day.
+    func status(for habit: Habit, on date: Date) -> Status {
+        let statuses = habit.subHabits.map { status(for: $0, on: date) }
+        if statuses.allSatisfy({ $0 == .completed }) {
+            return .completed
+        }
+        if statuses.contains(where: { $0 == .missed }) {
+            return .missed
+        }
+        return .inProgress
+    }
+
+    /// Calculates the first day of the week that contains the provided date.
+    private func startOfWeek(for date: Date) -> Date {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 2 // Monday
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        return calendar.date(from: components) ?? date
+    }
+}

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+struct HabitsView: View {
+    @ObservedObject var manager: DateManager
+    @ObservedObject var store: HabitStore
+    @State private var showEditor = false
+    @State private var habitName = ""
+    @State private var category: HabitCategory = .other
+    @State private var subHabitName = ""
+    @State private var target = 1
+
+    @State private var editingHabit: Habit?
+    @State private var renameTitle = ""
+    @State private var showRename = false
+    @State private var newSubName = ""
+    @State private var newSubTarget = 1
+    @State private var showAddSub = false
+
+    var body: some View {
+        VStack {
+            DateHeader(manager: manager)
+
+            List {
+                ForEach(store.habits(for: manager.selectedDate)) { habit in
+                    Section(header: habitHeader(habit)) {
+                        ForEach(habit.subHabits) { sub in
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(sub.title)
+                                    Text("\(store.progress(for: sub, on: manager.selectedDate))/\(sub.target)")
+                                        .font(.caption)
+                                        .foregroundColor(color(for: store.status(for: sub, on: manager.selectedDate)))
+                                }
+                                Spacer()
+                                if store.status(for: sub, on: manager.selectedDate) != .completed {
+                                    Button(action: { store.increment(sub, on: manager.selectedDate) }) {
+                                        Image(systemName: "plus.circle")
+                                    }
+                                } else {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(.green)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Button("Add Habit") {
+                habitName = ""
+                subHabitName = ""
+                target = 1
+                category = .other
+                showEditor = true
+            }
+            .padding()
+            .disabled(store.habits(for: manager.selectedDate).count >= 3)
+        }
+        .sheet(isPresented: $showEditor) {
+            NavigationView {
+                Form {
+                    Section("Main Habit") {
+                        TextField("Title", text: $habitName)
+                        Picker("Category", selection: $category) {
+                            ForEach(HabitCategory.allCases) { cat in
+                                Text(cat.rawValue).tag(cat)
+                            }
+                        }
+                    }
+                    Section("First Sub-Habit") {
+                        TextField("Title", text: $subHabitName)
+                        Stepper(value: $target, in: 1...10) {
+                            Text("Target: \(target)")
+                        }
+                    }
+                }
+                .navigationTitle("New Habit")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            store.addHabit(title: habitName,
+                                           category: category,
+                                           subHabitTitle: subHabitName,
+                                           target: target,
+                                           for: manager.selectedDate)
+                            showEditor = false
+                        }
+                    }
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { showEditor = false }
+                    }
+                }
+            }
+        }
+
+        .sheet(isPresented: $showRename) {
+            if let habit = editingHabit {
+                NavigationView {
+                    Form {
+                        TextField("Title", text: $renameTitle)
+                    }
+                    .navigationTitle("Rename Habit")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Save") {
+                                store.renameHabit(habit, to: renameTitle, for: manager.selectedDate)
+                                showRename = false
+                            }
+                        }
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { showRename = false }
+                        }
+                    }
+                }
+            }
+        }
+
+        .sheet(isPresented: $showAddSub) {
+            if let habit = editingHabit {
+                NavigationView {
+                    Form {
+                        TextField("Title", text: $newSubName)
+                        Stepper(value: $newSubTarget, in: 1...10) {
+                            Text("Target: \(newSubTarget)")
+                        }
+                    }
+                    .navigationTitle("New Sub-Habit")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Save") {
+                                store.addSubHabit(to: habit,
+                                                  title: newSubName,
+                                                  target: newSubTarget,
+                                                  for: manager.selectedDate)
+                                showAddSub = false
+                            }
+                        }
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { showAddSub = false }
+                        }
+                    }
+                }
+            }
+        }
+        }
+
+    private func color(for status: HabitStore.Status) -> Color {
+        switch status {
+        case .completed: return .green
+        case .missed: return .red
+        case .inProgress: return .orange
+        }
+    }
+
+    private var formattedDate: String {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f.string(from: manager.selectedDate)
+    }
+
+    private func habitHeader(_ habit: Habit) -> some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(habit.title)
+                Text(habit.category.rawValue)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            if store.status(for: habit, on: manager.selectedDate) == .completed {
+                Image(systemName: "checkmark.circle.fill").foregroundColor(.green)
+            }
+            Menu {
+                Button("Rename") {
+                    editingHabit = habit
+                    renameTitle = habit.title
+                    showRename = true
+                }
+                Button("Add Sub Habit") {
+                    editingHabit = habit
+                    newSubName = ""
+                    newSubTarget = 1
+                    showAddSub = true
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .rotationEffect(.degrees(90))
+                    .padding(.leading, 4)
+            }
+        }
+    }
+}
+
+#Preview {
+    HabitsView(manager: DateManager(), store: HabitStore())
+}


### PR DESCRIPTION
## Summary
- organize habits by week in `HabitStore`
- update `HabitsView` to fetch habits for the selected week and pass date when adding
- include helper to compute week start date
- support sub-habits, renaming and categories for main habits

## Testing
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_6855695966f0832fb4ef96c1b331dfdd