### PR TITLE
Implement habit level status

### DIFF
--- a/HabitJourney/HabitStore.swift
+++ b/HabitJourney/HabitStore.swift
@@ -109,6 +109,18 @@ class HabitStore: ObservableObject {
         let count = progress(for: subHabit, on: date)
         if count >= subHabit.target { return .completed }
 
+        let today = Calendar.current.startOfDay(for: Date())
+        let day = Calendar.current.startOfDay(for: date)
+        if day < today { return .missed }
+        return .inProgress
+    }
+
+    /// Returns the completion status for a full habit on a date. A habit is
+    /// completed only when all of its sub-habits are completed for the day.
+    func status(for habit: Habit, on date: Date) -> Status {
+        if habit.subHabits.allSatisfy({ status(for: $0, on: date) == .completed }) {
+            return .completed
+        }
 
         let today = Calendar.current.startOfDay(for: Date())
         let day = Calendar.current.startOfDay(for: date)

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -14,7 +14,7 @@ struct HabitsView: View {
     @State private var showRename = false
     @State private var newSubName = ""
     @State private var newSubTarget = 1
-    @State private var showAddSub = false
+    @State private var addSubParent: Habit?
 
 
     var body: some View {
@@ -120,29 +120,27 @@ struct HabitsView: View {
             }
         }
 
-        .sheet(isPresented: $showAddSub) {
-            if let habit = editingHabit {
-                NavigationView {
-                    Form {
-                        TextField("Title", text: $newSubName)
-                        Stepper(value: $newSubTarget, in: 1...10) {
-                            Text("Target: \(newSubTarget)")
+        .sheet(item: $addSubParent) { habit in
+            NavigationView {
+                Form {
+                    TextField("Title", text: $newSubName)
+                    Stepper(value: $newSubTarget, in: 1...10) {
+                        Text("Target: \(newSubTarget)")
+                    }
+                }
+                .navigationTitle("New Sub-Habit")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            store.addSubHabit(to: habit,
+                                              title: newSubName,
+                                              target: newSubTarget,
+                                              for: manager.selectedDate)
+                            addSubParent = nil
                         }
                     }
-                    .navigationTitle("New Sub-Habit")
-                    .toolbar {
-                        ToolbarItem(placement: .confirmationAction) {
-                            Button("Save") {
-                                store.addSubHabit(to: habit,
-                                                  title: newSubName,
-                                                  target: newSubTarget,
-                                                  for: manager.selectedDate)
-                                showAddSub = false
-                            }
-                        }
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button("Cancel") { showAddSub = false }
-                        }
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { addSubParent = nil }
                     }
                 }
             }
@@ -183,10 +181,9 @@ struct HabitsView: View {
                     showRename = true
                 }
                 Button("Add Sub Habit") {
-                    editingHabit = habit
+                    addSubParent = habit
                     newSubName = ""
                     newSubTarget = 1
-                    showAddSub = true
                 }
             } label: {
                 Image(systemName: "ellipsis")


### PR DESCRIPTION
## Summary
- implement `status(for: Habit, on:)` to calculate completion for full habits
- fix Add Sub Habit sheet to show form and save new sub-habits

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68557d796ae4832fa71c6b4fa0f5d796