### PR TITLE
Implement SwiftData persistence

### DIFF
--- a/HabitJourney/ContentView.swift
+++ b/HabitJourney/ContentView.swift
@@ -2,8 +2,14 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var dateManager = DateManager()
-    @StateObject private var diaryStore = DiaryStore()
-    @StateObject private var habitStore = HabitStore()
+    @StateObject private var diaryStore: DiaryStore
+    @StateObject private var habitStore: HabitStore
+
+    init() {
+        let context = ModelController.shared.container.mainContext
+        _diaryStore = StateObject(wrappedValue: DiaryStore(context: context))
+        _habitStore = StateObject(wrappedValue: HabitStore(context: context))
+    }
 
     var body: some View {
         TabView {

--- a/HabitJourney/DiaryEntry.swift
+++ b/HabitJourney/DiaryEntry.swift
@@ -1,12 +1,16 @@
 import Foundation
+import SwiftData
 
-struct DiaryEntry: Identifiable, Codable {
-    let id: UUID
+@Model
+final class DiaryEntry: Identifiable {
+    var id: UUID
+    var date: Date
     var thoughts: String
     var emotions: String
-    
-    init(id: UUID = UUID(), thoughts: String = "", emotions: String = "") {
+
+    init(id: UUID = UUID(), date: Date = Date(), thoughts: String = "", emotions: String = "") {
         self.id = id
+        self.date = date
         self.thoughts = thoughts
         self.emotions = emotions
     }

--- a/HabitJourney/DiaryStore.swift
+++ b/HabitJourney/DiaryStore.swift
@@ -1,17 +1,43 @@
 import Foundation
 import SwiftUI
+import SwiftData
 
+@MainActor
 class DiaryStore: ObservableObject {
     @Published private(set) var entries: [Date: DiaryEntry] = [:]
-    
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+        load()
+    }
+
+    private func load() {
+        let descriptor = FetchDescriptor<DiaryEntry>()
+        if let items = try? context.fetch(descriptor) {
+            for entry in items {
+                let day = Calendar.current.startOfDay(for: entry.date)
+                entries[day] = entry
+            }
+        }
+    }
+
     func entry(for date: Date) -> DiaryEntry? {
         let day = Calendar.current.startOfDay(for: date)
         return entries[day]
     }
-    
+
     func updateEntry(for date: Date, thoughts: String, emotions: String) {
         let day = Calendar.current.startOfDay(for: date)
-        let entry = DiaryEntry(thoughts: thoughts, emotions: emotions)
-        entries[day] = entry
+        if let existing = entries[day] {
+            existing.thoughts = thoughts
+            existing.emotions = emotions
+            existing.date = day
+        } else {
+            let entry = DiaryEntry(date: day, thoughts: thoughts, emotions: emotions)
+            context.insert(entry)
+            entries[day] = entry
+        }
+        try? context.save()
     }
 }

--- a/HabitJourney/DiaryView.swift
+++ b/HabitJourney/DiaryView.swift
@@ -84,5 +84,5 @@ struct DiaryView: View {
 }
 
 #Preview {
-    DiaryView(manager: DateManager(), store: DiaryStore())
+    DiaryView(manager: DateManager(), store: DiaryStore(context: ModelController.shared.container.mainContext))
 }

--- a/HabitJourney/HabitEntry.swift
+++ b/HabitJourney/HabitEntry.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 
 /// Categories a main habit can belong to.
 enum HabitCategory: String, CaseIterable, Codable, Identifiable {
@@ -10,8 +11,9 @@ enum HabitCategory: String, CaseIterable, Codable, Identifiable {
 }
 
 /// A single sub-habit that contributes to the completion of a main habit.
-struct SubHabit: Identifiable, Codable {
-    let id: UUID
+@Model
+final class SubHabit: Identifiable {
+    var id: UUID
     var title: String
     var target: Int
 
@@ -24,19 +26,44 @@ struct SubHabit: Identifiable, Codable {
 
 /// Main habit containing a set of sub-habits. The habit is completed once all
 /// sub-habits are completed for the day.
-struct Habit: Identifiable, Codable {
-    let id: UUID
+@Model
+final class Habit: Identifiable {
+    var id: UUID
     var title: String
     var category: HabitCategory
     var subHabits: [SubHabit]
+    var weekOf: Date
 
     init(id: UUID = UUID(),
          title: String = "",
          category: HabitCategory = .other,
-         subHabits: [SubHabit] = []) {
+         subHabits: [SubHabit] = [],
+         weekOf: Date) {
         self.id = id
         self.title = title
         self.category = category
         self.subHabits = subHabits
+        self.weekOf = weekOf
+    }
+}
+
+@Model
+final class HabitProgress: Identifiable {
+    var id: UUID
+    var habitID: UUID
+    var subHabitID: UUID?
+    var date: Date
+    var count: Int
+
+    init(id: UUID = UUID(),
+         habitID: UUID,
+         subHabitID: UUID? = nil,
+         date: Date,
+         count: Int = 0) {
+        self.id = id
+        self.habitID = habitID
+        self.subHabitID = subHabitID
+        self.date = date
+        self.count = count
     }
 }

--- a/HabitJourney/HabitJourneyApp.swift
+++ b/HabitJourney/HabitJourneyApp.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import SwiftData
 
 @main
 struct HabitJourneyApp: App {
+    private var container: ModelContainer = ModelController.shared.container
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .modelContainer(container)
         }
     }
 }

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -206,5 +206,5 @@ struct HabitsView: View {
 }
 
 #Preview {
-    HabitsView(manager: DateManager(), store: HabitStore())
+    HabitsView(manager: DateManager(), store: HabitStore(context: ModelController.shared.container.mainContext))
 }

--- a/HabitJourney/ModelController.swift
+++ b/HabitJourney/ModelController.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftData
+
+@MainActor
+class ModelController {
+    static let shared = ModelController()
+    let container: ModelContainer
+
+    private init() {
+        do {
+            container = try ModelContainer(for: Habit.self, SubHabit.self, DiaryEntry.self, HabitProgress.self)
+        } catch {
+            fatalError("Failed to create ModelContainer: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert diary and habit models to use `@Model`
- add `ModelController` to set up `ModelContainer`
- persist diary entries and habits with `ModelContext`
- wire up container in `HabitJourneyApp` and views

## Testing
- `xcodebuild -list -project HabitJourney.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6855f93a67a4832fb200c73d46e5b1fa