### PR TITLE
Implement habit notes and live progress update

### DIFF
--- a/HabitJourney/HabitEntry.swift
+++ b/HabitJourney/HabitEntry.swift
@@ -31,17 +31,20 @@ final class Habit: Identifiable {
     var id: UUID
     var title: String
     var category: HabitCategory
+    var notes: String
     var subHabits: [SubHabit]
     var weekOf: Date
 
     init(id: UUID = UUID(),
          title: String = "",
          category: HabitCategory = .other,
+         notes: String = "",
          subHabits: [SubHabit] = [],
          weekOf: Date) {
         self.id = id
         self.title = title
         self.category = category
+        self.notes = notes
         self.subHabits = subHabits
         self.weekOf = weekOf
     }

--- a/HabitJourney/HabitStore.swift
+++ b/HabitJourney/HabitStore.swift
@@ -40,11 +40,16 @@ class HabitStore: ObservableObject {
                   category: HabitCategory,
                   subHabitTitle: String,
                   target: Int,
+                  notes: String = "",
                   for date: Date) {
         let week = startOfWeek(for: date)
         guard weeklyHabits[week, default: []].count < 3 else { return }
         let sub = SubHabit(title: subHabitTitle, target: target)
-        let habit = Habit(title: title, category: category, subHabits: [sub], weekOf: week)
+        let habit = Habit(title: title,
+                          category: category,
+                          notes: notes,
+                          subHabits: [sub],
+                          weekOf: week)
         context.insert(habit)
         weeklyHabits[week, default: []].append(habit)
         try? context.save()
@@ -60,6 +65,13 @@ class HabitStore: ObservableObject {
     func addSubHabit(to habit: Habit, title: String, target: Int, for date: Date) {
         habit.subHabits.append(SubHabit(title: title, target: target))
         try? context.save()
+    }
+
+    /// Update the notes for an existing habit.
+    func updateNotes(for habit: Habit, notes: String) {
+        habit.notes = notes
+        try? context.save()
+        objectWillChange.send()
     }
 
     // MARK: Progress helpers
@@ -102,6 +114,7 @@ class HabitStore: ObservableObject {
             context.insert(progress)
         }
         try? context.save()
+        objectWillChange.send()
     }
 
     /// Convenience method to increase progress by one.

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -8,6 +8,7 @@ struct HabitsView: View {
     @State private var category: HabitCategory = .other
     @State private var subHabitName = ""
     @State private var target = 1
+    @State private var notes = ""
 
     @State private var editingHabit: Habit?
     @State private var renameTitle = ""
@@ -15,6 +16,8 @@ struct HabitsView: View {
     @State private var newSubName = ""
     @State private var newSubTarget = 1
     @State private var addSubParent: Habit?
+    @State private var editingNotesHabit: Habit?
+    @State private var noteDraft = ""
 
 
     var body: some View {
@@ -24,6 +27,11 @@ struct HabitsView: View {
             List {
                 ForEach(store.habits(for: manager.selectedDate)) { habit in
                     Section(header: habitHeader(habit)) {
+                        if !habit.notes.isEmpty {
+                            Text(habit.notes)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
                         ForEach(habit.subHabits) { sub in
                             HStack {
                                 VStack(alignment: .leading) {
@@ -57,6 +65,7 @@ struct HabitsView: View {
                 subHabitName = ""
                 target = 1
                 category = .other
+                notes = ""
 
                 showEditor = true
             }
@@ -75,6 +84,10 @@ struct HabitsView: View {
                             }
                         }
                     }
+                    Section("Notes") {
+                        TextEditor(text: $notes)
+                            .frame(minHeight: 80)
+                    }
                     Section("First Sub-Habit") {
                         TextField("Title", text: $subHabitName)
                         Stepper(value: $target, in: 1...10) {
@@ -91,6 +104,7 @@ struct HabitsView: View {
                                            category: category,
                                            subHabitTitle: subHabitName,
                                            target: target,
+                                           notes: notes,
                                            for: manager.selectedDate)
 
                             showEditor = false
@@ -120,6 +134,27 @@ struct HabitsView: View {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Cancel") { showRename = false }
                         }
+                    }
+                }
+            }
+        }
+
+        .sheet(item: $editingNotesHabit) { habit in
+            NavigationView {
+                Form {
+                    TextEditor(text: $noteDraft)
+                        .frame(minHeight: 100)
+                }
+                .navigationTitle("Habit Notes")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            store.updateNotes(for: habit, notes: noteDraft)
+                            editingNotesHabit = nil
+                        }
+                    }
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { editingNotesHabit = nil }
                     }
                 }
             }
@@ -194,6 +229,10 @@ struct HabitsView: View {
                     addSubParent = habit
                     newSubName = ""
                     newSubTarget = 1
+                }
+                Button("Edit Notes") {
+                    editingNotesHabit = habit
+                    noteDraft = habit.notes
                 }
             } label: {
                 Image(systemName: "ellipsis")


### PR DESCRIPTION
## Summary
- add `notes` property to `Habit`
- allow adding notes when creating or editing habits
- show notes in habit list sections
- update store to persist habit notes
- send `objectWillChange` when updating progress so UI refreshes instantly

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b08be7638832f8f8d211927aa8a1a