### PR TITLE
Improve habit view interactions

### DIFF
--- a/HabitJourney/DiaryStore.swift
+++ b/HabitJourney/DiaryStore.swift
@@ -39,5 +39,6 @@ class DiaryStore: ObservableObject {
             entries[day] = entry
         }
         try? context.save()
+        objectWillChange.send()
     }
 }

--- a/HabitJourney/DiaryView.swift
+++ b/HabitJourney/DiaryView.swift
@@ -13,12 +13,20 @@ struct DiaryView: View {
 
             if let entry = store.entry(for: manager.selectedDate) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Thoughts")
-                        .font(.headline)
+                    Label {
+                        Text("Thoughts")
+                    } icon: {
+                        Image(systemName: "lightbulb")
+                    }
+                    .font(.headline)
                     Text(entry.thoughts)
                     Divider()
-                    Text("Emotions")
-                        .font(.headline)
+                    Label {
+                        Text("Emotions")
+                    } icon: {
+                        Image(systemName: "face.smiling")
+                    }
+                    .font(.headline)
                     Text(entry.emotions)
                 }
                 .padding()
@@ -36,22 +44,41 @@ struct DiaryView: View {
 
             Spacer()
 
-            Button(store.entry(for: manager.selectedDate) == nil ? "Add Entry" : "Edit Entry") {
+            Button {
                 let existing = store.entry(for: manager.selectedDate)
                 draftThoughts = existing?.thoughts ?? ""
                 draftEmotions = existing?.emotions ?? ""
                 showEditor = true
+            } label: {
+                if store.entry(for: manager.selectedDate) == nil {
+                    Label("Add Entry", systemImage: "plus.circle")
+                } else {
+                    Label("Edit Entry", systemImage: "pencil.circle")
+                }
             }
             .buttonStyle(.borderedProminent)
+            .font(.title2)
             .padding()
         }
         .sheet(isPresented: $showEditor) {
             NavigationView {
                 Form {
-                    Section(header: Text("Thoughts")) {
+                    Section(header:
+                                Label {
+                                    Text("Thoughts")
+                                } icon: {
+                                    Image(systemName: "lightbulb")
+                                }
+                                .font(.headline)) {
                         TextEditor(text: $draftThoughts).frame(minHeight: 100)
                     }
-                    Section(header: Text("Emotions")) {
+                    Section(header:
+                                Label {
+                                    Text("Emotions")
+                                } icon: {
+                                    Image(systemName: "face.smiling")
+                                }
+                                .font(.headline)) {
                         TextEditor(text: $draftEmotions).frame(minHeight: 100)
                     }
                 }

--- a/HabitJourney/HabitEntry.swift
+++ b/HabitJourney/HabitEntry.swift
@@ -8,6 +8,15 @@ enum HabitCategory: String, CaseIterable, Codable, Identifiable {
     case other = "Other"
 
     var id: String { rawValue }
+
+    /// SFSymbol representing the category for display purposes.
+    var icon: String {
+        switch self {
+        case .learning: return "book.fill"
+        case .body: return "figure.strengthtraining.traditional"
+        case .other: return "circle.grid.3x3.fill"
+        }
+    }
 }
 
 /// A single sub-habit that contributes to the completion of a main habit.

--- a/HabitJourney/HabitStore.swift
+++ b/HabitJourney/HabitStore.swift
@@ -48,18 +48,21 @@ class HabitStore: ObservableObject {
         context.insert(habit)
         weeklyHabits[week, default: []].append(habit)
         try? context.save()
+        objectWillChange.send()
     }
 
     /// Rename an existing habit in a given week.
     func renameHabit(_ habit: Habit, to newTitle: String, for date: Date) {
         habit.title = newTitle
         try? context.save()
+        objectWillChange.send()
     }
 
     /// Add a new sub-habit to an existing habit in the given week.
     func addSubHabit(to habit: Habit, title: String, target: Int, for date: Date) {
         habit.subHabits.append(SubHabit(title: title, target: target))
         try? context.save()
+        objectWillChange.send()
     }
 
     // MARK: Progress helpers
@@ -102,6 +105,7 @@ class HabitStore: ObservableObject {
             context.insert(progress)
         }
         try? context.save()
+        objectWillChange.send()
     }
 
     /// Convenience method to increase progress by one.

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -39,15 +39,18 @@ struct HabitsView: View {
 
             Spacer()
 
-            Button("Add Habit") {
+            Button {
                 habitName = ""
                 subHabitName = ""
                 target = 1
                 category = .other
 
                 showEditor = true
+            } label: {
+                Label("Add Habit", systemImage: "plus.circle")
             }
             .buttonStyle(.borderedProminent)
+            .font(.title2)
             .padding()
             .disabled(store.habits(for: manager.selectedDate).count >= 3)
         }
@@ -58,14 +61,16 @@ struct HabitsView: View {
                         TextField("Title", text: $habitName)
                         Picker("Category", selection: $category) {
                             ForEach(HabitCategory.allCases) { cat in
-                                Text(cat.rawValue).tag(cat)
+                                Label(cat.rawValue, systemImage: cat.icon)
+                                    .tag(cat)
                             }
                         }
                     }
                     Section("First Sub-Habit") {
                         TextField("Title", text: $subHabitName)
                         Stepper(value: $target, in: 1...10) {
-                            Text("Target: \(target)")
+                            Label("Target: \(target)", systemImage: "target")
+                                .font(.headline)
                         }
 
                     }
@@ -117,7 +122,8 @@ struct HabitsView: View {
                 Form {
                     TextField("Title", text: $newSubName)
                     Stepper(value: $newSubTarget, in: 1...10) {
-                        Text("Target: \(newSubTarget)")
+                        Label("Target: \(newSubTarget)", systemImage: "target")
+                            .font(.headline)
                     }
                 }
                 .navigationTitle("New Sub-Habit")
@@ -161,9 +167,13 @@ struct HabitsView: View {
 
     private func habitHeader(_ habit: Habit) -> some View {
         HStack {
+            Image(systemName: habit.category.icon)
+                .foregroundColor(.accentColor)
+                .padding(.trailing, 4)
             VStack(alignment: .leading) {
                 Text(habit.title)
-                Text(habit.category.rawValue)
+                    .font(.title2)
+                Label(habit.category.rawValue, systemImage: habit.category.icon)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -185,7 +195,8 @@ struct HabitsView: View {
             } label: {
                 Image(systemName: "ellipsis")
                     .rotationEffect(.degrees(90))
-                    .padding(.leading, 4)
+                    .padding(8)
+                    .frame(minWidth: 44, minHeight: 44)
             }
         }
     }


### PR DESCRIPTION
## Summary
- refresh UI when progress changes by notifying observers
- enlarge font for Habit addition forms and Diary entry UI
- enlarge Add Habit/Add Entry buttons and Stepper labels
- show category icons for habit categories
- **add icons for Add Entry/Add Habit buttons and for Thoughts, Emotions, and Target labels**

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6880019a1d98832fab9683727d5005cc