### PR TITLE
Enhance habit header actions

### DIFF
--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -160,34 +160,37 @@ struct HabitsView: View {
     }
 
     private func habitHeader(_ habit: Habit) -> some View {
-        HStack {
+        HStack(alignment: .top) {
             VStack(alignment: .leading) {
                 Text(habit.title)
+                    .font(.title3)
+                    .fontWeight(.semibold)
                 Text(habit.category.rawValue)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
             Spacer()
             if store.status(for: habit, on: manager.selectedDate) == .completed {
-                Image(systemName: "checkmark.circle.fill").foregroundColor(.green)
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
             }
-            Menu {
-                Button("Rename") {
-                    editingHabit = habit
-                    renameTitle = habit.title
-                    showRename = true
-                }
-                Button("Add Sub Habit") {
-                    addSubParent = habit
-                    newSubName = ""
-                    newSubTarget = 1
-                }
+            Button {
+                addSubParent = habit
+                newSubName = ""
+                newSubTarget = 1
             } label: {
-                Image(systemName: "ellipsis")
-                    .rotationEffect(.degrees(90))
-                    .padding(.leading, 4)
+                Image(systemName: "plus.circle")
+            }
+
+            Button {
+                editingHabit = habit
+                renameTitle = habit.title
+                showRename = true
+            } label: {
+                Image(systemName: "pencil.circle")
             }
         }
+        .padding(.bottom, 8)
     }
 
     private func habitCard(_ habit: Habit) -> some View {
@@ -215,6 +218,13 @@ struct HabitsView: View {
                             .foregroundColor(.green)
                     }
                 }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color(.systemBackground))
+                )
+                .shadow(color: Color.black.opacity(0.1), radius: 1, x: 0, y: 1)
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
- keep bigger semibold habit title
- move add and rename buttons next to title
- add vertical space below header

## Testing
- `swiftc --version`
- `xcodebuild -list -project HabitJourney.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d9a3a814832fb170b175bafe1f95