### PR TITLE
Fix sub habit counter

### DIFF
--- a/HabitJourney/HabitStore.swift
+++ b/HabitJourney/HabitStore.swift
@@ -107,7 +107,8 @@ class HabitStore: ObservableObject {
     /// Convenience method to increase progress by one.
     func increment(_ subHabit: SubHabit, on date: Date) {
         let current = progress(for: subHabit, on: date)
-        setProgress(current + 1, for: subHabit, on: date)
+        let newValue = min(current + 1, subHabit.target)
+        setProgress(newValue, for: subHabit, on: date)
     }
     // MARK: Progress helpers
 

--- a/HabitJourney/HabitsView.swift
+++ b/HabitJourney/HabitsView.swift
@@ -201,10 +201,11 @@ struct HabitsView: View {
                 HStack {
                     VStack(alignment: .leading) {
                         Text(sub.title)
-                        ProgressView(value: Double(store.progress(for: sub, on: manager.selectedDate)), total: Double(sub.target))
+                        let progress = store.progress(for: sub, on: manager.selectedDate)
+                        ProgressView(value: Double(min(progress, sub.target)), total: Double(sub.target))
                             .progressViewStyle(.linear)
                             .tint(color(for: store.status(for: sub, on: manager.selectedDate)))
-                        Text("\(store.progress(for: sub, on: manager.selectedDate))/\(sub.target)")
+                        Text("\(progress)/\(sub.target)")
                             .font(.caption)
                             .foregroundColor(color(for: store.status(for: sub, on: manager.selectedDate)))
                     }
@@ -218,7 +219,8 @@ struct HabitsView: View {
                             .foregroundColor(.green)
                     }
                 }
-                .padding(8)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 4)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
                     RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
## Summary
- trim horizontal padding for each sub habit card
- clamp progress values in `HabitsView`
- prevent going over the target when incrementing

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6887e05586a4832f83aea05f558577e1