### PR TITLE
Fix habit progress updating

### DIFF
--- a/HabitJourney/HabitStore.swift
+++ b/HabitJourney/HabitStore.swift
@@ -83,6 +83,9 @@ class HabitStore: ObservableObject {
 
     /// Sets the progress for a sub-habit on the provided date.
     func setProgress(_ value: Int, for subHabit: SubHabit, on date: Date) {
+        // Notify listeners that progress will change so the UI refreshes
+        objectWillChange.send()
+
         let dayStart = Calendar.current.startOfDay(for: date)
         guard let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart) else { return }
         let subHabitID = subHabit.id


### PR DESCRIPTION
## Summary
- emit `objectWillChange` when modifying habit progress so the UI refreshes immediately

## Testing
- `swiftc -emit-sil -o /tmp/out.sil HabitJourney/HabitStore.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887e6517510832fa4b1bbfd4d0c9857